### PR TITLE
Ensure that all transitive requirements are installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'django-admin-display',
         'django-allauth',
         'django-composed-configuration[dev,prod]>=0.10.0',
-        'django-configurations',
+        'django-configurations[database,email]',
         'django-extensions',
         'django-filter',
         'django-oauth-toolkit',


### PR DESCRIPTION
The old pip resolver does not properly fetch transitive requirements in certain cases. Until the new pip resolver is available more consistently, this works around the bug.