### PR TITLE
Enabled mypy and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,52 @@
 # Optimal Transport Morphometry
 
 ## Develop with Docker (recommended quickstart)
+
 This is the simplest configuration for developers to start with.
 
 ### Initial Setup
+
 1. Run `docker-compose run --rm django ./manage.py migrate`
 2. Run `docker-compose run --rm django ./manage.py createsuperuser`
    and follow the prompts to create your own user
+3. Run `docker-compose run --rm django ./manage.py populate_db sample_data/oasis_small.csv` to seed the database and generate a sample dataset.
 
 ### Run Application
+
 1. Run `docker-compose up`
-2. Access the site, starting at http://localhost:8000/admin/
+2. Access the site, starting at <http://localhost:8000/admin/>
 3. When finished, use `Ctrl+C`
 
 ### Application Maintenance
+
 Occasionally, new package dependencies or schema changes will necessitate
 maintenance. To non-destructively update your development stack at any time:
+
 1. Run `docker-compose pull`
 2. Run `docker-compose build --pull --no-cache`
 3. Run `docker-compose run --rm django ./manage.py migrate`
 
 ## Develop Natively (advanced)
+
 This configuration still uses Docker to run attached services in the background,
 but allows developers to run Python code on their native system.
 
 ### Initial Setup
+
 1. Run `docker-compose -f ./docker-compose.yml up -d`
 2. Install Python 3.8
 3. Install
    [`psycopg2` build prerequisites](https://www.psycopg.org/docs/install.html#build-prerequisites)
-4. Create and activate a new Python virtualenv
+4. Create and activate a new Python virtual environment
 5. Run `pip install -e .[dev]`
 6. Run `source ./dev/export-env.sh`
 7. Run `./manage.py migrate`
 8. Run `./manage.py createsuperuser` and follow the prompts to create your own user
+9. Run `./manage.py populate_db sample_data/oasis_small.csv`
 
 ### Run Application
-1.  Ensure `docker-compose -f ./docker-compose.yml up -d` is still active
+
+1. Ensure `docker-compose -f ./docker-compose.yml up -d` is still active
 2. Run:
    1. `source ./dev/export-env.sh`
    2. `./manage.py runserver`
@@ -46,15 +56,18 @@ but allows developers to run Python code on their native system.
 4. When finished, run `docker-compose stop`
 
 ## Remap Service Ports (optional)
+
 Attached services may be exposed to the host system via alternative ports. Developers who work
 on multiple software projects concurrently may find this helpful to avoid port conflicts.
 
 To do so, before running any `docker-compose` commands, set any of the environment variables:
+
 * `DOCKER_POSTGRES_PORT`
 * `DOCKER_RABBITMQ_PORT`
 * `DOCKER_MINIO_PORT`
 
 The Django server must be informed about the changes:
+
 * When running the "Develop with Docker" configuration, override the environment variables:
   * `DJANGO_MINIO_STORAGE_MEDIA_URL`, using the port from `DOCKER_MINIO_PORT`.
 * When running the "Develop Natively" configuration, override the environment variables:
@@ -66,7 +79,9 @@ Since most of Django's environment variables contain additional content, use the
 the appropriate `dev/.env.docker-compose*` file as a baseline for overrides.
 
 ## Testing
+
 ### Initial Setup
+
 tox is used to execute all tests.
 tox is installed automatically with the `dev` package extra.
 
@@ -74,11 +89,13 @@ When running the "Develop with Docker" configuration, all tox commands must be r
 `docker-compose run --rm django tox`; extra arguments may also be appended to this form.
 
 ### Running Tests
+
 Run `tox` to launch the full test suite.
 
 Individual test environments may be selectively run.
 This also allows additional options to be be added.
 Useful sub-commands include:
+
 * `tox -e lint`: Run only the style checks
 * `tox -e type`: Run only the type checks
 * `tox -e test`: Run only the pytest-driven tests
@@ -91,7 +108,9 @@ some (but not all) of the style checks, run `tox -e format`.
 Developers should run the following command to generate a dataset and relevant
 image data in their dev instance:
 
-`docker-compose run --rm django ./manage.py populate_db sample_data/oasis_small.csv`
+```bash
+docker-compose run --rm django ./manage.py populate_db sample_data/oasis_small.csv
+```
 
 For now, this ensures the existence of a test dataset, and generates a pending upload
 batch into it.

--- a/optimal_transport_morphometry/core/tasks.py
+++ b/optimal_transport_morphometry/core/tasks.py
@@ -189,12 +189,12 @@ def _delete_preprocessing_artifacts(image: models.Image) -> None:
         models.RegisteredImage,
         models.FeatureImage,
     ]:
-        model.objects.filter(source_image=image).delete()
+        model.objects.filter(source_image=image).delete()  # type: ignore
 
 
 def _already_preprocessed(image: models.Image) -> bool:
     return all(
-        model.objects.filter(source_image=image).count() > 0
+        model.objects.filter(source_image=image).count() > 0  # type: ignore
         for model in [
             models.JacobianImage,
             models.SegmentedImage,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 line-length = 100
 skip-string-normalization = true
 target-version = ["py38"]
-exclude='\.eggs|\.git|\.mypy_cache|\.tox|\.env|\.venv|env|venv|_build|buck-out|build|dist'
+exclude = '\.eggs|\.git|\.mypy_cache|\.tox|\.env|\.venv|env|venv|_build|buck-out|build|dist'
 
 [tool.isort]
 profile = "black"
@@ -11,3 +11,16 @@ line_length = 100
 force_sort_within_sections = true
 # Combines "as" imports on the same line
 combine_as_imports = true
+
+[tool.mypy]
+python_version = 3.8
+ignore_missing_imports = true
+show_error_context = true
+show_column_numbers = true
+show_error_codes = true
+pretty = true
+exclude = '\.eggs|\.git|\.mypy_cache|\.tox|\.env|\.venv|env|venv|_build|buck-out|build|dist'
+
+[[tool.mypy.overrides]]
+module = 'optimal_transport_morphometry.core.models.*'
+ignore_errors = true

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     django-stubs
     djangorestframework-stubs
 commands =
-    mypy {posargs:.}
+    mypy --install-types --non-interactive {posargs:.}
 
 [testenv:format]
 skipsdist = true
@@ -74,24 +74,22 @@ commands =
 max-line-length = 100
 show-source = True
 ignore =
-    # closing bracket does not match indentation of opening bracket’s line
-    E123
-    # whitespace before ':'
-    E203,
-    # line break before binary operator
-    W503,
-    # Missing docstring in *
-    D10,
+    D10,  # Missing docstring (errors D100 - D107)
+    E123, # Closing bracket does not match indentation of opening bracket's line
+    E203, # Whitespace before ':'
+    W503, # Line break occurred before a binary operator
 exclude =
     .git,
     __pycache__,
     .tox,
+    .mypy_cache,
     .eggs,
     *.egg,
     .env,
     .venv,
     env,
     venv,
+black-config = pyproject.toml
 
 [pytest]
 DJANGO_SETTINGS_MODULE = optimal_transport_morphometry.settings


### PR DESCRIPTION
Enabled `mypy` and updated `tox` configs. Can now run `tox -e type` to properly perform type checks.

Updated README to include database seeding information in the quickstart. This allows the `Develop with Docker (recommended quickstart)` section in the README to be completely self contained and everything needed to start the server. 